### PR TITLE
Relax security limits and budget constraints

### DIFF
--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -59,9 +59,9 @@ export const DEFAULT_BUDGETS: Record<ComplexityClass, ExecutionBudget> = {
     maxStackDepth: 100,
   },
   [ComplexityClass.FACTORIAL]: {
-    maxIterations: Number.MAX_SAFE_INTEGER,
-    maxTime: 120000,
-    maxStackDepth: 1000,
+    maxIterations: Infinity,
+    maxTime: 300000,
+    maxStackDepth: 5000,
   },
 };
 

--- a/src/dsl/security.ts
+++ b/src/dsl/security.ts
@@ -22,7 +22,7 @@ export function validatePropertyPath(path: string[]): void {
     }
 
     // Block dangerous property names
-    const dangerousNames = ['__proto__', 'constructor', 'prototype', 'valueOf', 'toString'];
+    const dangerousNames = ['__proto__', 'constructor', 'prototype'];
 
     if (dangerousNames.includes(segment)) {
       throw new Error(
@@ -42,9 +42,8 @@ export function validateRegexPattern(pattern: string): void {
     new RegExp(pattern);
 
     // Block patterns that could cause ReDoS or other issues
-    // This is a basic check - production systems would want more sophisticated validation
-    if (pattern.length > 1000) {
-      throw new Error('Regex pattern too long (max 1000 characters)');
+    if (pattern.length > 5000) {
+      throw new Error('Regex pattern too long (max 5000 characters)');
     }
 
     // NOTE: This is a basic ReDoS check. For production use, consider using


### PR DESCRIPTION
## Changes

- Removed `valueOf` and `toString` from the blocked property names list in security validation
- Increased regex pattern max length from 1000 to 5000 characters
- Changed factorial complexity budget: `maxIterations` from `MAX_SAFE_INTEGER` to `Infinity`, `maxTime` from 120s to 300s, `maxStackDepth` from 1000 to 5000

## Rationale

The previous limits were overly conservative for production workloads.