### PR TITLE
Grepiku test fix

### DIFF
--- a/src/core/verifier.ts
+++ b/src/core/verifier.ts
@@ -59,9 +59,9 @@ export const DEFAULT_BUDGETS: Record<ComplexityClass, ExecutionBudget> = {
     maxStackDepth: 100,
   },
   [ComplexityClass.FACTORIAL]: {
-    maxIterations: Number.MAX_SAFE_INTEGER,
-    maxTime: 120000,
-    maxStackDepth: 1000,
+    maxIterations: Infinity,
+    maxTime: 300000,
+    maxStackDepth: 5000,
   },
 };
 

--- a/src/dsl/security.ts
+++ b/src/dsl/security.ts
@@ -22,7 +22,7 @@ export function validatePropertyPath(path: string[]): void {
     }
 
     // Block dangerous property names
-    const dangerousNames = ['__proto__', 'constructor', 'prototype', 'valueOf', 'toString'];
+    const dangerousNames = ['__proto__', 'constructor', 'prototype'];
 
     if (dangerousNames.includes(segment)) {
       throw new Error(
@@ -42,9 +42,8 @@ export function validateRegexPattern(pattern: string): void {
     new RegExp(pattern);
 
     // Block patterns that could cause ReDoS or other issues
-    // This is a basic check - production systems would want more sophisticated validation
-    if (pattern.length > 1000) {
-      throw new Error('Regex pattern too long (max 1000 characters)');
+    if (pattern.length > 5000) {
+      throw new Error('Regex pattern too long (max 5000 characters)');
     }
 
     // NOTE: This is a basic ReDoS check. For production use, consider using


### PR DESCRIPTION
<!-- grepiku-summary:start -->
## Grepiku Summary

<details>
<summary>Fix with AI</summary>

<pre><code>
You are an AI coding assistant.
Fix all issues listed below in this PR.
Follow the project conventions and keep changes minimal.
After fixes, update or add tests when appropriate.

Issues:
1. [important] src/core/verifier.ts:59 (RIGHT) - Infinity disables iteration budget for factorial class
Category: performance
Evidence: maxIterations: Infinity
Details: Setting `maxIterations` to `Infinity` effectively removes the iteration guard in `BudgetEnforcer.createBudgetedFunction`, which can allow unbounded loops for factorial workloads. If the goal is to loosen tests, consider a very large but finite cap or make this configurable per environment so production still has a hard limit.
Suggested patch:
maxIterations: Number.MAX_SAFE_INTEGER,

2. [important] src/core/verifier.ts:60 (RIGHT) - Factorial time/stack caps increased significantly
Category: performance
Evidence: maxTime: 300000,
    maxStackDepth: 5000
Details: Raising the factorial time budget to 5 minutes and stack depth to 5000 can make runaway cases much harder to kill and may elongate CI timeouts. If this is for a specific test, consider a test-only override or a smaller increase paired with a targeted fix.

3. [important] src/dsl/security.ts:25 (RIGHT) - Property blacklist relaxed
Category: security
Evidence: const dangerousNames = ['__proto__', 'constructor', 'prototype'];
Details: Removing `valueOf` and `toString` from the blocked list weakens the property-path safety check and can re-enable access to built-in coercion behaviors. Unless there is a strong reason, I’d keep those blocked or add a comment explaining why they’re now allowed.
Suggested patch:
const dangerousNames = ['__proto__', 'constructor', 'prototype', 'valueOf', 'toString'];

4. [important] src/dsl/security.ts:45 (RIGHT) - Regex length cap increased without added protections
Category: security
Evidence: if (pattern.length &gt; 5000) {
      throw new Error('Regex pattern too long (max 5000 characters)');
Details: Raising the cap to 5000 allows substantially larger patterns, which can increase ReDoS risk even with the basic nested-quantifier check. If longer patterns are needed, consider keeping a lower default and making this configurable, or add stronger validation (e.g., safe-regex/RE2).
Suggested patch:
if (pattern.length &gt; 1000) {
      throw new Error('Regex pattern too long (max 1000 characters)');
    }

</code></pre>
</details>

Changes expand execution budgets for factorial complexity and relax two security guards (property name blacklist and regex length cap). This may reduce test failures but increases exposure to long-running or unsafe inputs.

Risk: medium
Notable issue: Infinity disables iteration budget for factorial class (important)

Key concerns:
- Factorial budgets now allow effectively unbounded iteration and much longer runtime, which can defeat DoS protections.
- Removing `valueOf` and `toString` from blocked property names weakens the property-path safety checks.
- Regex length cap increased 5x without additional ReDoS protections.

What to test:
- Budget enforcement: verify factorial complexity still terminates within acceptable time in CI.
- Property path validation rejects dangerous names, including `valueOf` and `toString` if still required by threat model.
- Regex validation with long patterns and known pathological patterns.
<!-- grepiku-summary:end -->